### PR TITLE
feat(attendre-chargement-page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Cette application est basée sur l'extension Chrome GreenIT-Analysis (https://gi
 # Sommaire
 - [Principe de l'outil](#principe-de-loutil)
 - [Utiliser l'outil](#utiliser-loutil)
+  - [Fichier d'input : url.yaml](#fichier-dinput--urlyaml)
   - [Node.js](#nodejs)
     - [Prérequis](#prérequis)
     - [Installation](#installation)
@@ -18,13 +19,38 @@ Cette application est basée sur l'extension Chrome GreenIT-Analysis (https://gi
 - [Usage](#usage)
 
 # Principe de l'outil
-Cet outil simule l'exécution de l'extension sur les pages spécifiées ouvertes dans Chromium en passant par Puppeteer pour récuperer les résultats.
+Cet outil simule l'exécution de l'extension sur les pages spécifiées ouvertes dans Chromium en passant par Puppeteer pour récuperer les résultats. 
+
+Le système de cache est désactivé pour fiabiliser l'analyse d'une page.
+
+Cet outil utilise par défaut la fonction `page.waitForNavigation({waitUntil: 'networkidle2'})` de Puppeteer afin d'attendre la fin de chargement d'une page.
 
 # Utiliser l'outil
-Pour utiliser l'outil, un fichier YAML listant toutes les URL à analyser est nécéssaire.
+
+## Fichier d'input : url.yaml
+
+Pour utiliser l'outil, un fichier YAML listant toutes les URL à analyser est nécéssaire. 
+
+Sa structure est la suivante :
+
+| Paramètre         | Type   | Obligatoire | Description                                                         |
+| ----------------- | ------ | ----------- | ------------------------------------------------------------------- |
+| `url`             | string | Oui         | URL de la page à analyser                                           |
+| `waitForSelector` | string | Non         | Attend que l'élément HTML définit par le sélecteur CSS soit visible |
+| `waitForXPath`    | string | Non         | Attend que l'élément HTML définit par le XPath soit visible         |
+
+Exemple de fichier `url.yaml` : 
 ```yaml
-- https://collectif.greenit.fr/
-- https://collectif.greenit.fr/outils.html
+# Analyse l'URL collectif.greenit.fr 
+- url : 'https://collectif.greenit.fr/'
+
+# Analyse l'URL collectif.greenit.fr/outils.html en spécifiant une condition d'attente via un sélecteur CSS
+- url : 'https://collectif.greenit.fr/outils.html'
+  waitForSelector: '#header'
+
+# Analyse l'URL collectif.greenit.fr/index_en.html en spécifiant une condition d'attente via un XPath
+- url : 'https://collectif.greenit.fr/index_en.html'
+  waitForXPath: '//section[2]/div/h2'
 ```
 
 ## Node.js

--- a/cli-core/report.js
+++ b/cli-core/report.js
@@ -16,7 +16,7 @@ function worstPagesHandler(number){
         }
         let addObj = {
             nb : obj.nb,
-            url : obj.url,
+            url : obj.pageInformations.url,
             grade : obj.grade,
             ecoIndex : obj.ecoIndex
         }
@@ -73,7 +73,7 @@ async function create_global_report(reports,options){
     //Creating one report sheet per file
     reports.forEach((file)=>{
         let obj = JSON.parse(fs.readFileSync(file.path).toString());
-        if (!hostname) hostname = obj.url.split('/')[2]
+        if (!hostname) hostname = obj.pageInformations.url.split('/')[2]
         obj.nb = parseInt(file.name);
         //handle potential failed analyse
         if (obj.success) {
@@ -85,11 +85,11 @@ async function create_global_report(reports,options){
             }
         } else{
             err.push({
-            nb : obj.nb,
-            url : obj.url,
-            grade : obj.grade,
-            ecoIndex : obj.ecoIndex
-            })
+                nb : obj.nb,
+                url : obj.pageInformations.url,
+                grade : obj.grade,
+                ecoIndex : obj.ecoIndex
+            });
         }
         if (progressBar) progressBar.tick()
     })
@@ -201,7 +201,7 @@ async function create_XLSX_report(reportObject,options){
 
         // Prepare data
         let sheet_data = [
-            [ "URL", obj.url],
+            [ "URL", obj.pageInformations.url],
             [ "Grade", obj.grade],
             [ "EcoIndex", obj.ecoIndex],
             [ "Eau (cl)", obj.waterConsumption],

--- a/commands/analyse.js
+++ b/commands/analyse.js
@@ -2,17 +2,17 @@ const fs = require('fs');
 const YAML = require('yaml');
 const path = require('path');
 const puppeteer = require('puppeteer');
-const createJsonReports = require('../cli-core/analyis.js').createJsonReports;
-const login = require('../cli-core/analyis.js').login;
+const createJsonReports = require('../cli-core/analysis.js').createJsonReports;
+const login = require('../cli-core/analysis.js').login;
 const create_global_report = require('../cli-core/report.js').create_global_report;
 const create_XLSX_report = require('../cli-core/report.js').create_XLSX_report;
 //launch core
 async function analyse_core(options) {
     const URL_YAML_FILE = path.resolve(options.yaml_input_file);
-    //Get list of url
-    let urlTable;
+    //Get list of pages to analyze and its informations
+    let pagesInformations;
     try {
-        urlTable = YAML.parse(fs.readFileSync(URL_YAML_FILE).toString());
+        pagesInformations = YAML.parse(fs.readFileSync(URL_YAML_FILE).toString());
     } catch (error) {
         throw ` yaml_input_file : "${URL_YAML_FILE}" is not a valid YAML file.`
     }
@@ -45,7 +45,7 @@ async function analyse_core(options) {
             await login(browser, loginInfos)
         }
         //analyse
-        reports = await createJsonReports(browser, urlTable, options);
+        reports = await createJsonReports(browser, pagesInformations, options);
     } finally {
         //close browser
         let pages = await browser.pages();

--- a/greenit
+++ b/greenit
@@ -18,7 +18,7 @@ yargs(hideBin(process.argv))
       .option('timeout', {
         alias: 't',
         type: 'number',
-        description: 'Timout for an analysis of a URL in ms',
+        description: 'Timeout for an analysis of a URL in ms',
         default: 180000
       })
       .option('retry', {


### PR DESCRIPTION
**Objectif** : fiabiliser l'analyse. 

**Constat** : lorsque j'analyse une application : 
- via GreenIT-Analysis-cli : mon site obtient une note de 65
- via le plugin GreenIT-Analysis lancé à la main : mon site obtient une note de 50

**Contenu** : 
- Désactivation du cache
- Mise en place d'une condition d'attente du chargement de la page par défaut via `page.waitForNavigation({waitUntil: 'networkidle2'})`
- Si on le souhaite, il est possible de customiser cette condition d'attente en renseignant dans le fichier `url.yaml` un attribut `waitForSelector` ou `waitForXPath`
- J'en ai aussi profité pour renommer `analyis.js` en `analysis.js`
- Le paramètre `--timeout` est pris en compte lors de l'appel de la fonction waitForNavigation/waitForSelector/waitForXPath