### PR TITLE
Fix/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # See : https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
 FROM node:14-slim
+ARG url_path="/app/input/url.yaml"
+ARG results_path="/app/output/results.xlsx"
 RUN apt-get update \
     && apt-get install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -20,4 +22,4 @@ USER pptruser
 # To avoid "Error: ENOENT: no such file or directory, open '/app/dist/bundle.js'"
 RUN npm i
 
-CMD ["greenit","analyse", "url.yaml", "results/results.xlsx"]
+CMD greenit analyse $url_path $results_path

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,7 @@ RUN npm i \
     && chown -R pptruser:pptruser /home/pptruser \
     && chown -R pptruser:pptruser /app/
 USER pptruser
+# To avoid "Error: ENOENT: no such file or directory, open '/app/dist/bundle.js'"
+RUN npm i
 
 CMD ["greenit","analyse", "url.yaml", "results/results.xlsx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node
+# See : https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
+FROM node:14-slim
 RUN apt-get update \
     && apt-get install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # See : https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
 FROM node:14-slim
-ARG url_path="/app/input/url.yaml"
-ARG results_path="/app/output/results.xlsx"
 RUN apt-get update \
     && apt-get install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -22,4 +20,6 @@ USER pptruser
 # To avoid "Error: ENOENT: no such file or directory, open '/app/dist/bundle.js'"
 RUN npm i
 
-CMD greenit analyse $url_path $results_path
+ENV URL_PATH="/app/input/url.yaml"
+ENV RESULTS_PATH="/app/output/results.xlsx"
+CMD greenit analyse $URL_PATH $RESULTS_PATH

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm link
  ```
 4. Autoriser tous les utilisateurs à écrire dans le dossier `/<path>/output` :
  ```
- chmod 777 /<path>/input
+ chmod 777 /<path>/output
  ```
 5. Récupérer le code source : 
  ```

--- a/README.md
+++ b/README.md
@@ -170,7 +170,23 @@ docker run -it --init --rm --cap-add=SYS_ADMIN \
 ```
 3. Récupérer les résultats dans votre dossier `/<path>/output`
 
-Remarque : vous pouvez surcharger la commande renseignée par défaut dans le Dockerfile.
+#### Redéfinir les variables `URL_PATH` et `RESULTS_PATH` 
+
+Vous pouvez redéfinir les variables `URL_PATH` et `RESULTS_PATH` si vous souhaitez changer le nom des fichiers ou leur emplacement.
+
+Exemple :
+```
+docker run -it --init --rm --cap-add=SYS_ADMIN \
+  -v /<path>/input:/app/input \
+  -v /<path>/output:/app/output  \
+  -e "URL_PATH=/app/input/myapp_url.yaml" \
+  -e "RESULTS_PATH=/app/output/results_20210101.xlsx" \
+  --name containerName \
+  imageName
+```
+
+#### Surcharger l'instruction CMD définie dans le Dockerfile 
+Vous pouvez surcharger la commande renseignée par défaut dans le Dockerfile.
 
 Exemple : 
 ```


### PR DESCRIPTION
**Objectif** : corriger le build et le lancement de l'analyse via Docker

**Erreurs corrigées** : 
- **Première erreur détectée (build)** : Initialement, le Dockerfile se basait sur l'image de node sans spécifier de version. Actuellement, c'est la version 16 qui provoque l'erreur suivante : 
```
ERROR: Failed to set up Chromium r818858! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
npm ERR! TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
``` 
La correction consiste donc à spécifier la dernière version LTS de Node : 
```
FROM node:14-slim
``` 
- **Deuxième erreur détectée (run)** : corriger l'instruction CMD
```
/bin/sh: 1: [greenit,: not found
```
La correction consiste à modifier :
```
CMD ["greenit","analyse", "url.yaml", "results/results.xlsx"] 
```
En :
```
CMD greenit analyse $url_path $results_path
```
J'en ai aussi profité pour externaliser dans des arguments le fichier url.yaml et results.xlsx de façon à utiliser des volumes. Ainsi, le fichier url.yaml ne doit plus forcément être à la racine au moment du build. L'intérêt est de pouvoir le modifier sans avoir à rebuilder l'image.

- **Troisième erreur détectée** (run) : `Error: ENOENT: no such file or directory, open '/app/dist/bundle.js'`
La solution que j'ai trouvé pour corriger cette erreur consiste à relancer l'instruction `npm i` avec le user `pptruser`  