### PR TITLE
feat(ajouter-headers): Configuration possible des headers http

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ Choix :
 - xlsx 
 - html
 
+- `--headers , -h` : Chemin vers le fichier YAML contenant les headers HTTP configurés pour accéder aux URL à analyser.
+
+  Exemple de headers.yaml :
+  ```yaml
+  accept: 'text/html,application/xhtml+xml,application/xml'
+  accept-encoding: 'gzip, deflate, br'
+  accept-language: 'en-US,en;q=0.9,en;q=0.8'
+  ```
+
 ### Usage avec Docker
 1. Déposer le fichier `<url_input_file>` dans le dossier `/<path>/input`.
 2. Lancer l'analyse :

--- a/cli-core/analysis.js
+++ b/cli-core/analysis.js
@@ -20,9 +20,17 @@ async function analyseURL(browser, pageInformations, options) {
 
     try {
         const page = await browser.newPage();
+
+        // configure proxy in page browser
         if (PROXY) {
             await page.authenticate({ username: PROXY.user, password: PROXY.password });
         }
+
+        // configure headers http
+        if (options.headers) {
+            await page.setExtraHTTPHeaders(options.headers);
+        }
+
         await page.setViewport(sizes[DEVICE]);
 
         // disabling cache
@@ -145,7 +153,7 @@ async function login(browser,loginInformations) {
 }
 
 //Core
-async function createJsonReports(browser, pagesInformations, options, proxy) {
+async function createJsonReports(browser, pagesInformations, options, proxy, headers) {
     //Timeout for an analysis
     const TIMEOUT = options.timeout;
     //Concurent tab
@@ -193,7 +201,8 @@ async function createJsonReports(browser, pagesInformations, options, proxy) {
             device: DEVICE,
             timeout:TIMEOUT,
             tabId: i,
-            proxy: proxy
+            proxy: proxy,
+            headers: headers
         }));
         index++;
         //console.log(`Start of analysis #${index}/${pagesInformations.length}`)
@@ -207,7 +216,8 @@ async function createJsonReports(browser, pagesInformations, options, proxy) {
                 timeout:TIMEOUT,
                 tabId: results.tabId,
                 tryNb: results.tryNb + 1,
-                proxy: proxy
+                proxy: proxy,
+                headers: headers
             })); // convert is NEEDED, variable size array
         }else{
             let filePath = path.resolve(SUBRESULTS_DIRECTORY,`${resultId}.json`)
@@ -230,7 +240,8 @@ async function createJsonReports(browser, pagesInformations, options, proxy) {
                     device: DEVICE,
                     timeout:TIMEOUT,
                     tabId: results.tabId,
-                    proxy: proxy
+                    proxy: proxy,
+                    headers: headers
                 })); // No need for convert, fixed size array
                 index++;
                 //console.log(`Start of analysis #${index}/${pagesInformations.length}`)

--- a/cli-core/template/page.html
+++ b/cli-core/template/page.html
@@ -115,7 +115,7 @@
 <body>
     <nav class="navbar navbar-success bg-success text-white mb-4">
         <div class="container-fluid">
-            <span class="navbar-brand mb-0 h1" style="font-size: 1rem;" thjs:utext="${header}">GreenIT-Analysis report > <a class="text-white" href="http://10.132.7.169:81/conso/supervision/supervision/suivi-traitements">RPT | Données patrimoniales réseau</a></span>
+            <span class="navbar-brand mb-0 h1" style="font-size: 1rem;" thjs:utext="${header}">GreenIT-Analysis report > <a class="text-white" href="http://foo/bar">Foo - Bar</a></span>
             <div class="d-flex flex-row-reverse">
                 <div id="date" thjs:text="${date}">05/05/2021 10:03:12</div>
             </div>

--- a/greenit
+++ b/greenit
@@ -64,6 +64,11 @@ yargs(hideBin(process.argv))
         description: 'Report format : Possible choices : excel (default), html',
         default: 'excel'
       })
+      .option('headers', {
+        alias: 'h',
+        type: 'string',
+        description: 'Headers HTTP to configure to analyze url',
+      })
   }, (argv) => {
       require("./commands/analyse.js")(argv)
   })


### PR DESCRIPTION
Ajout d'une fonctionnalité qui donne la possibilité de configurer les headers HTTP de la requête HTTP au moment d'accéder à une URL via le navigateur Chromium.