### PR TITLE
fix(#13): Correction du rapport HTML quand aucun nom n'est spécifié pour chaque URL

### DIFF
--- a/cli-core/analysis.js
+++ b/cli-core/analysis.js
@@ -105,6 +105,7 @@ async function analyseURL(browser, pageInformations, options) {
     result.pageInformations = pageInformations;
     result.tryNb = TRY_NB;
     result.tabId = TAB_ID;
+    result.index = options.index;
     return result;
 }
 
@@ -258,7 +259,8 @@ async function createJsonReports(browser, pagesInformations, options, proxy, hea
             timeout:TIMEOUT,
             tabId: i,
             proxy: proxy,
-            headers: headers
+            headers: headers,
+            index: index
         }));
         index++;
         //console.log(`Start of analysis #${index}/${pagesInformations.length}`)
@@ -273,7 +275,8 @@ async function createJsonReports(browser, pagesInformations, options, proxy, hea
                 tabId: results.tabId,
                 tryNb: results.tryNb + 1,
                 proxy: proxy,
-                headers: headers
+                headers: headers,
+                index: results.index
             })); // convert is NEEDED, variable size array
         }else{
             let filePath = path.resolve(SUBRESULTS_DIRECTORY,`${resultId}.json`)
@@ -297,7 +300,8 @@ async function createJsonReports(browser, pagesInformations, options, proxy, hea
                     timeout:TIMEOUT,
                     tabId: results.tabId,
                     proxy: proxy,
-                    headers: headers
+                    headers: headers,
+                    index
                 })); // No need for convert, fixed size array
                 index++;
                 //console.log(`Start of analysis #${index}/${pagesInformations.length}`)

--- a/cli-core/reportHtml.js
+++ b/cli-core/reportHtml.js
@@ -59,7 +59,7 @@ function readAllReports(fileList) {
     fileList.forEach((file)=>{
         let report_data = JSON.parse(fs.readFileSync(file.path).toString());
         const pageName = report_data.pageInformations.name || report_data.pageInformations.url;
-        const pageFilename = report_data.pageInformations.name ? `${removeForbiddenCharacters(report_data.pageInformations.name)}.html` : `${report_data.tabId}.html`;
+        const pageFilename = report_data.pageInformations.name ? `${removeForbiddenCharacters(report_data.pageInformations.name)}.html` : `${report_data.index}.html`;
 
         if (report_data.success) {
             let bestPractices = extractBestPractices(report_data.bestPractices);


### PR DESCRIPTION
Correction de l'issue #13 : lorsque l'analyse de plus de 40 URL se font en parallèle (40 étant la valeur par défaut du nombre maximum d'URL analysées simultanément), les rapports html des URL n°41, 42, ... écrasaient les 40 premières URL car elles utilisent le même tabId. 

La correction a consisté à utiliser l'index dans le fichier url.yaml plutôt que le tabId.