### PR TITLE
FIX(rapport-html): Génération du rapport à partir de n'importe quel d…

### DIFF
--- a/cli-core/reportHtml.js
+++ b/cli-core/reportHtml.js
@@ -162,7 +162,7 @@ function extractBestPractices(bestPracticesFromReport) {
 }
 
 function writeGlobalReport(templateEngine, globalReportVariables, outputFile) {
-    templateEngine.processFile('cli-core/template/global.html', globalReportVariables)
+    templateEngine.processFile(path.join(__dirname, 'template/global.html'), globalReportVariables)
     .then(globalReportHtml => {
         fs.writeFileSync(outputFile, globalReportHtml);
     })
@@ -173,7 +173,7 @@ function writeGlobalReport(templateEngine, globalReportVariables, outputFile) {
 
 function writeAllReports(templateEngine, allReportsVariables, outputFolder) {
     allReportsVariables.forEach(reportVariables => {
-        templateEngine.processFile('cli-core/template/page.html', reportVariables)
+        templateEngine.processFile(path.join(__dirname, 'template/page.html'), reportVariables)
         .then(singleReportHtml => {
             fs.writeFileSync(`${outputFolder}/${reportVariables.filename}`, singleReportHtml);
         })


### PR DESCRIPTION
Bonsoir,

J'ai remarqué que la génération du rapport HTML se faisait correctement lorsque je lançais la commande `./greenit analyse ../url.yml ../index.html --format=html` à l'intérieur du dossier contenant les sources mais que le programme jetait une erreur si je l'appelais ailleurs (contrairement à la génération du rapport au format .xlsx qui fonctionne dans tous les cas).

Par exemple: `./GreenIT-Analysis-cli/greenit analyse url.yml index.html --format=html` ne fonctionne pas:

![image](https://user-images.githubusercontent.com/24924824/156815144-f14c55ea-f742-48bc-87f1-08f6e4086ad7.png)


J'ai juste modifié le chemin des fichiers de template pour qu'il soit absolu avec __dirname au lieu d'être relatif comme c'était le cas auparavant.