### PR TITLE
feat(#32): Amélioration de la gestion du paramètre --format

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Paramètres optionnels :
   password: "<password>"
   ```
 
-- `--format , -f` : Format du rapport. (Valeur par défaut : "xlsx")
+- `--format , -f` : Format du rapport. Ce paramètre est optionnel : s'il n'est pas défini, alors le format sera déduit en fonction de l'extension du fichier du rapport. Lorsqu'il est défini, le paramètre format est prioritaire vis-à-vis de l'extension.
 
 Choix :
 - xlsx 
@@ -389,7 +389,9 @@ docker run -it --init --rm --cap-add=SYS_ADMIN \
 
 #### Excel (xlsx)
 
-Prérequis : le fichier de sortie doit avoir l'extension `.xlsx`.
+Prérequis : 
+- Soit le paramètre suivant est définit : `--format=xlsx` ou `-f=xlsx`
+- Soit le fichier de sortie doit avoir l'extension `.xlsx`
 
 Exemple de commande : 
 
@@ -413,8 +415,9 @@ Exemple d'un rapport :
 #### HTML
 
 Prérequis : 
-- le fichier de sortie doit avoir l'extension `.html`
-- le paramètre `--format=html` ou `-f=html` doit être utilisé 
+Prérequis : 
+- Soit le paramètre suivant est définit : `--format=html` ou `-f=html`
+- Soit le fichier de sortie doit avoir l'extension `.html`
 
 Exemple de commande : 
 

--- a/cli-core/reportExcel.js
+++ b/cli-core/reportExcel.js
@@ -5,12 +5,7 @@ const ProgressBar = require('progress');
 
 //create xlsx report for all the analysed pages and recap on the first sheet
 async function create_XLSX_report(reportObject, options){
-    //Path of the output file
     const OUTPUT_FILE = path.resolve(options.report_output_file);
-    if (!OUTPUT_FILE.toLowerCase().endsWith('.xlsx')) {
-        throw ` report_output_file : File "${OUTPUT_FILE}" does not end with the ".xlsx" extension.`
-    }
-
     const fileList = reportObject.reports;
     const globalReport = reportObject.globalReport;
 

--- a/cli-core/reportHtml.js
+++ b/cli-core/reportHtml.js
@@ -15,12 +15,7 @@ const cssBestPractices = {
 
 //create html report for all the analysed pages and recap on the first sheet
 async function create_html_report(reportObject,options){
-    //Path of the output file
     const OUTPUT_FILE = path.resolve(options.report_output_file);
-    if (!OUTPUT_FILE.toLowerCase().endsWith('.html')) {
-        throw ` report_output_file : File "${OUTPUT_FILE}" does not end with the ".html" extension.`
-    }
-
     const fileList = reportObject.reports;
     const globalReport = reportObject.globalReport;
 

--- a/commands/analyse.js
+++ b/commands/analyse.js
@@ -36,6 +36,12 @@ async function analyse_core(options) {
         headers = readHeaders(options.headers);
     }
 
+    // Get and check report format
+    const reportFormat = getReportFormat(options.format, options.report_output_file);
+    if (!reportFormat) {
+        throw 'Format not supported. Use --format option or report file extension to define a supported extension.'
+    }
+
     //start browser
     const browser = await puppeteer.launch({
         headless: true,
@@ -70,7 +76,7 @@ async function analyse_core(options) {
     }
     //create report
     let reportObj = await create_global_report(reports, options);
-    if(options.format === 'html') {
+    if (reportFormat === 'html') {
         await create_html_report(reportObj, options);
     } else {
         await create_XLSX_report(reportObj, options);
@@ -101,6 +107,22 @@ function readHeaders(headersFile) {
         throw ` --headers : "${HEADERS_YAML_FILE}" is not a valid YAML file.`
     }
     return headers;
+}
+
+function getReportFormat(format, filename) {
+    // Check if format is defined
+    const formats = ['xlsx', 'html'];
+    if (format && formats.includes(format.toLowerCase())) {
+        return format.toLowerCase();
+    }
+
+    // Else, check extension
+    const filenameLC = filename.toLowerCase();
+    const extensionFormat = formats.find(format => filenameLC.endsWith(`.${format}`));
+    if (extensionFormat) {
+        console.log(`No output format specified, defaulting to ${extensionFormat} based on output file name.`);
+    }
+    return extensionFormat;
 }
 
 //export method that handle error

--- a/greenit
+++ b/greenit
@@ -61,8 +61,7 @@ yargs(hideBin(process.argv))
       .option('format', {
         alias: 'f',
         type: 'string',
-        description: 'Report format : Possible choices : excel (default), html',
-        default: 'excel'
+        description: 'Report format : Possible choices : xlsx (excel), html'
       })
       .option('headers', {
         alias: 'h',


### PR DESCRIPTION
Si l'option `--format` est définie, alors ça sera le format du fichier de sortie.
Sinon, on utilise l'extension du fichier de sortie pour déterminer le format.

Fixes #32