### PR TITLE
Fix #29 - Screenshots after actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ Il est possible de définir une liste d'actions à travers le champ `actions` qu
 | `waitForSelector`   | string | Non         | Attend que l'élément HTML définit par le sélecteur CSS soit visible         |
 | `waitForXPath`      | string | Non         | Attend que l'élément HTML définit par le XPath soit visible                 |
 | `waitForNavigation` | string | Non         | Attend la fin du chargement de la page. 4 valeurs possibles : `load`, `domcontentloaded`, `networkidle0`, `networkidle2` |
+| `screenshot`       | string | Non         | Réalise une capture d'écran de la page, après avoir réalisé l'action. La valeur à renseigner est le nom de la capture d'écran. La capture d'écran est réalisée même si l'action est en erreur. |
 
-Les conditions de type `waitFor` peuvent être réutilisées afin de définir une condition d'attente après l'exécution de l'action. Elles restent optionnelles.
+Les conditions de type `waitFor` peuvent être réutilisées afin de définir une condition d'attente après l'exécution de l'action. Elles restent optionnelles. La capture d'écran, le cas échéant, est réalisé après cette condition d'attente.
 
 Des paramètres supplémentaires peuvent être nécessaires selon le type de l'action.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Il est possible de définir une liste d'actions à travers le champ `actions` qu
 | `waitForNavigation` | string | Non         | Attend la fin du chargement de la page. 4 valeurs possibles : `load`, `domcontentloaded`, `networkidle0`, `networkidle2` |
 | `screenshot`       | string | Non         | Réalise une capture d'écran de la page, après avoir réalisé l'action. La valeur à renseigner est le nom de la capture d'écran. La capture d'écran est réalisée même si l'action est en erreur. |
 
-Les conditions de type `waitFor` peuvent être réutilisées afin de définir une condition d'attente après l'exécution de l'action. Elles restent optionnelles. La capture d'écran, le cas échéant, est réalisé après cette condition d'attente.
+Les conditions de type `waitFor` peuvent être réutilisées afin de définir une condition d'attente après l'exécution de l'action. Elles restent optionnelles. La capture d'écran, le cas échéant, est réalisée après cette condition d'attente.
+
 
 Des paramètres supplémentaires peuvent être nécessaires selon le type de l'action.
 

--- a/cli-core/analysis.js
+++ b/cli-core/analysis.js
@@ -153,8 +153,6 @@ async function startActions(page, actions, TIMEOUT) {
             } else {
                 console.log("Unknown action for '" + actionName + "' : " + action.type);
             }
-        } catch (e) {
-            throw e;
         } finally {
             if (action.screenshot) {
                 await takeScreenshot(page, action.screenshot);

--- a/cli-core/analysis.js
+++ b/cli-core/analysis.js
@@ -142,22 +142,30 @@ async function startActions(page, actions, TIMEOUT) {
             await page.waitForTimeout(timeout);
         }
 
-        if (action.type === "click") {
-            await page.click(action.element);
-            await waitPageLoading(page, action, TIMEOUT);
-        } else if (action.type === "text") {
-            await page.type(action.element, action.content, {delay: 100});
-            await waitPageLoading(page, action, TIMEOUT);
-        } else if (action.type === "select") {
-            let args = [action.element].concat(action.values);
-            // equivalent to : page.select(action.element, action.values[0], action.values[1], ...)
-            await page.select.apply(page, args);
-            await waitPageLoading(page, action, TIMEOUT);
-        } else if (action.type === "scroll") {
-            await scrollToBottom(page);
-            await waitPageLoading(page, action, TIMEOUT);
-        } else {
-            console.log("Unknown action for '" + actionName + "' : " + action.type);
+        try {
+            if (action.type === "click") {
+                await page.click(action.element);
+                await waitPageLoading(page, action, TIMEOUT);
+            } else if (action.type === "text") {
+                await page.type(action.element, action.content, {delay: 100});
+                await waitPageLoading(page, action, TIMEOUT);
+            } else if (action.type === "select") {
+                let args = [action.element].concat(action.values);
+                // equivalent to : page.select(action.element, action.values[0], action.values[1], ...)
+                await page.select.apply(page, args);
+                await waitPageLoading(page, action, TIMEOUT);
+            } else if (action.type === "scroll") {
+                await scrollToBottom(page);
+                await waitPageLoading(page, action, TIMEOUT);
+            } else {
+                console.log("Unknown action for '" + actionName + "' : " + action.type);
+            }
+        } catch (e) {
+            throw e;
+        } finally {
+            if (action.screenshot) {
+                await takeScreenshot(page, action.screenshot);
+            }
         }
     }
 }

--- a/cli-core/analysis.js
+++ b/cli-core/analysis.js
@@ -53,16 +53,9 @@ async function analyseURL(browser, pageInformations, options) {
             }
         }
 
-        try {
-            if (pageInformations.actions) {
-                // Execute actions on page (click, text, ...)
-                await startActions(page, pageInformations.actions, TIMEOUT);
-            }
-        } finally {
-            // Take screenshot (even if the action fails)
-            if (pageInformations.actions && pageInformations.actions.screenshot) {
-                await takeScreenshot(page, pageInformations.actions.screenshot);
-            }
+        if (pageInformations.actions) {
+            // Execute actions on page (click, text, ...)
+            await startActions(page, pageInformations.actions, TIMEOUT);
         }
 
         let harObj = await pptrHar.stop();


### PR DESCRIPTION
Cette PR correspond à l'issue #29, elle inclut : 
* la possibilité de faire un screenshot après chaque action
* la mise à jour de la documentation
* la suppression du screenshot général après toutes les actions : il était bugué et ne semble plus nécessaire si on peut prendre des screenshots pour chaque action. Il reste bien sur le screenshot pris avant les actions.