### PR TITLE
fix(#44): ajout libx11-xcb1 et maj node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See : https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
-FROM node:14-slim
+FROM node:16-slim
 
 # Uncomment if you need to configure proxy. 
 # You can init these variables by using --build-args during docker build
@@ -13,7 +13,7 @@ RUN apt-get update \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libx11-xcb1 \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app


### PR DESCRIPTION
- Ajout de la dépendance libx11-xcb1 requise pour assurer
  le bon fonctionnement de Chrome dans le conteneur Docker
- Montée de version vers Node.js 16 (LTS)

Fixes cnumr/GreenIT-Analysis-cli#44