### PR TITLE
Ajout d'un paramètre headless pour désactiver le mode en local

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Choix :
 - `--influxdb_org` : Nom de l'organisation influxdb
 - `--influxdb_token` : Token de connexion pour influxdb
 - `--influxdb_bucket` : Bucket infludb sur lequel envoyer les données
+- `--headless` : Paramètre permettant d'activer ou de désactiver le mode headless. Lorsque ce mode est désactivé, cela permet de visualiser l'automatisation des actions dans le navigateur. Valeurs possibles : [`true`, `false`]. Valeur par défaut : `true`.
 
 ### Usage avec Docker
 1. Déposer le fichier `<url_input_file>` dans le dossier `/<path>/input`.

--- a/commands/analyse.js
+++ b/commands/analyse.js
@@ -49,7 +49,7 @@ async function analyse_core(options) {
 
     //start browser
     const browser = await puppeteer.launch({
-        headless: true,
+        headless: options.headless,
         args: browserArgs,
         // Keep gpu horsepower in headless
         ignoreDefaultArgs: [

--- a/greenit
+++ b/greenit
@@ -80,6 +80,11 @@ yargs(hideBin(process.argv))
       .option('influxdb_org', {
         type: 'string'
       })
+      .option('headless', {
+        type: 'boolean',
+        description: 'Option to enable or disable web browser headless mode',
+        default: true
+      })
   }, (argv) => {
       require("./commands/analyse.js")(argv)
   })


### PR DESCRIPTION
Objectif : permettre de désactiver le mode headless lorsqu'on veut lancer l'analyse en local avec npm et qu'on souhaite visualiser les actions automatisées dans le navigateur.

Utile pour faire du debug.