### PR TITLE
fix(): Erreur 'Target closed' dans une CI

### DIFF
--- a/commands/analyse.js
+++ b/commands/analyse.js
@@ -22,7 +22,8 @@ async function analyse_core(options) {
 
     let browserArgs = [
         "--no-sandbox",                 // can't run inside docker without
-        "--disable-setuid-sandbox"      // but security issues
+        "--disable-setuid-sandbox",     // but security issues
+        "--single-process"
     ]
 
     // Add proxy conf in browserArgs
@@ -87,7 +88,7 @@ async function analyse_core(options) {
     else {
         await create_XLSX_report(reportObj, options);
     }
-    
+
 }
 
 function readProxy(proxyFile) {

--- a/commands/analyse.js
+++ b/commands/analyse.js
@@ -20,11 +20,11 @@ async function analyse_core(options) {
         throw ` url_input_file : "${URL_YAML_FILE}" is not a valid YAML file: ${error.code} at ${JSON.stringify(error.linePos)}.`
     }
 
+    let additionalArgs = String(options.chrome_flags).split(" ");
     let browserArgs = [
         "--no-sandbox",                 // can't run inside docker without
         "--disable-setuid-sandbox",     // but security issues
-        "--single-process"
-    ]
+    ].concat(additionalArgs);
 
     // Add proxy conf in browserArgs
     let proxy = {};

--- a/greenit
+++ b/greenit
@@ -85,6 +85,11 @@ yargs(hideBin(process.argv))
         description: 'Option to enable or disable web browser headless mode',
         default: true
       })
+      .option('chrome_flags', {
+        type: 'array',
+        description: 'Additional Chrome flags. Example: --chrome-flags="--flag1 --flag2"',
+        default: []
+      })
   }, (argv) => {
       require("./commands/analyse.js")(argv)
   })


### PR DESCRIPTION
J'aimerais proposer une PR pour qu'il soit possible d'ajouter des flags chrome à l'exécution des analyses. Cela me permet d'éviter des erreurs lorsque j'utilise GreenIT-Analysis-cli dans une CI.

Je n'ai pas créé d'issue Github avant mais il m'arrivait de rencontrer cette erreur : 
```
Error while analyzing URL [REDACTED] :  Error: Protocol error (Target.createTarget): Target closed.
    at /app/node_modules/puppeteer/lib/cjs/puppeteer/common/Connection.js:71:63
    at new Promise (<anonymous>)
    at Connection.send (/app/node_modules/puppeteer/lib/cjs/puppeteer/common/Connection.js:70:16)
    at Browser._createPageInContext (/app/node_modules/puppeteer/lib/cjs/puppeteer/common/Browser.js:221:53)
    at BrowserContext.newPage (/app/node_modules/puppeteer/lib/cjs/puppeteer/common/Browser.js:500:30)
    at Browser.newPage (/app/node_modules/puppeteer/lib/cjs/puppeteer/common/Browser.js:214:37)
    at analyseURL (/app/cli-core/analysis.js:22:36)
    at createJsonReports (/app/cli-core/analysis.js:266:29)
    at analyse_core (/app/commands/analyse.js:77:25)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
Pour la corriger, j'ajoute le flag `--single-process`

N'hésitez pas à me dire si la forme ne convient pas ou si vous avez besoin de plus d'information