### PR TITLE
fix: installation manuelle de chrome dans docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN npm i \
 USER pptruser
 
 # To avoid "Error: ENOENT: no such file or directory, open '/app/dist/greenItBundle.js'"
-RUN npm i
+RUN npm i \
+    && node node_modules/puppeteer/install.mjs
 
 ENV URL_PATH="/app/input/url.yaml"
 ENV RESULTS_PATH="/app/output/results.xlsx"


### PR DESCRIPTION
Suite à la montée de version de Puppeteer en 21.5.2, une erreur est présente lors du lancement de l'outil via Docker : `Error: Could not find Chrome`.

Solution : https://github.com/puppeteer/puppeteer/issues/10388#issuecomment-1780202103