### PR TITLE
feat(#83): Amélioration de la fonctionnalité login et ajout de waitForTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Sa structure est la suivante :
 | `waitForSelector`   | string | Non         | Attend que l'élément HTML définit par le sélecteur CSS soit visible |
 | `waitForXPath`      | string | Non         | Attend que l'élément HTML définit par le XPath soit visible         |
 | `waitForNavigation` | string | Non         | Attend la fin du chargement de la page. 4 valeurs possibles : `load`, `domcontentloaded`, `networkidle0`, `networkidle2` |
+| `waitForTimeout`    | int    | Non         | Attend X ms, X étant égal à la valeur du paramètre                  |
 | `screenshot`        | string | Non         | Réalise une capture d'écran de la page à analyser. La valeur à renseigner est le nom de la capture d'écran. La capture d'écran est réalisée même si le chargement de la page est en erreur. |
 | `actions`           | list   | Non         | Réalise une suite d'actions avant d'analyser la page                |
 
@@ -205,6 +206,7 @@ Il est possible de définir une liste d'actions à travers le champ `actions` qu
 | `waitForSelector`   | string  | Non         | Attend que l'élément HTML définit par le sélecteur CSS soit visible         |
 | `waitForXPath`      | string  | Non         | Attend que l'élément HTML définit par le XPath soit visible                 |
 | `waitForNavigation` | string  | Non         | Attend la fin du chargement de la page. 4 valeurs possibles : `load`, `domcontentloaded`, `networkidle0`, `networkidle2` |
+| `waitForTimeout`    | int    | Non         | Attend X ms, X étant égal à la valeur du paramètre                  |
 | `screenshot`       | string   | Non         | Réalise une capture d'écran de la page, après avoir réalisé l'action. La valeur à renseigner est le nom de la capture d'écran. La capture d'écran est réalisée même si l'action est en erreur. |
 
 Les conditions de type `waitFor` peuvent être réutilisées afin de définir une condition d'attente après l'exécution de l'action. Elles restent optionnelles. La capture d'écran, le cas échéant, est réalisée après cette condition d'attente.
@@ -351,6 +353,7 @@ Choix :
     - selector: '#passwordFieldId'
       value: password
   loginButtonSelector: '#loginButtonId'
+  waitForTimeout: 2000
   ```
 
   Plus d'informations sur les selectors : https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors

--- a/README_EN.md
+++ b/README_EN.md
@@ -160,9 +160,10 @@ Sa structure est la suivante :
 | `name`              | string | No          | Name of the page to analyze displayed in the report                  |
 | `waitForSelector`   | string | No          | Waits for the HTML element defined by the CSS selector to be visible |
 | `waitForXPath`      | string | No          | Waits for the HTML element defined by the CSS selector to be visible |
-| `waitForNavigation` | string | No          | Waits for the page to finish loading. 4 possible values: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`                                                                  |
-| `screenshot`        | string | No         | Takes a screenshot of the page to analyze. The value to enter is the name of the screenshot. The screenshot is taken even if the page loads in error.                                            |
-| `actions`           | list   | No         | Perform a series of actions before analyzing the page                 |
+| `waitForNavigation` | string | No          | Waits for the page to finish loading. 4 possible values: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`                                                                                      |
+| `waitForTimeout`    | int    | No          | Wait X ms, X being equal to the value of the parameter               |
+| `screenshot`        | string | No          | Takes a screenshot of the page to analyze. The value to enter is the name of the screenshot. The screenshot is taken even if the page loads in error.                                                |
+| `actions`           | list   | No          | Perform a series of actions before analyzing the page                |
 
 #### Waiting conditions
 The `waitForNavigation` parameter uses Puppeteer features to detect the end of loading a page without using a CSS selector or an XPath :
@@ -209,6 +210,7 @@ It is possible to define a list of actions through the `actions` field which is 
 | `waitForSelector`   | string | No        | Waits for the HTML element defined by the CSS selector to be visible        |
 | `waitForXPath`      | string | No        | Waits for the HTML element defined by the XPath to be visible               |
 | `waitForNavigation` | string | No        | Waits for the page to finish loading. 4 possible values: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`                                                                       |
+| `waitForTimeout`    | int    | No        | Wait X ms, X being equal to the value of the parameter               |
 | `screenshot`       | string | No         | Take a screenshot of the page, after performing the action. The value to enter is the name of the screenshot. The screenshot is taken even if the action is in error.                                   |
 
 Conditions of type `waitFor` can be reused to define a wait condition after the execution of the action. They remain optional. The screenshot, if applicable, is taken after this wait condition.
@@ -353,6 +355,7 @@ Choice :
     - selector: "#passwordFieldId"
       value: password
   loginButtonSelector: "#loginButtonId"
+  waitForTimeout: 2000
   ```
 
   More information on selectors: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors

--- a/cli-core/analysis.js
+++ b/cli-core/analysis.js
@@ -73,6 +73,8 @@ async function waitPageLoading(page, pageInformations, TIMEOUT) {
         await page.waitForXPath(pageInformations.waitForXPath, { visible: true, timeout: TIMEOUT });
     } else if (isValidWaitForNavigation(pageInformations.waitForNavigation)) {
         await page.waitForNavigation({ waitUntil: pageInformations.waitForNavigation, timeout: TIMEOUT });
+    } else if (pageInformations.waitForTimeout) {
+        await page.waitForTimeout(pageInformations.waitForTimeout)
     }
 }
 
@@ -324,11 +326,16 @@ async function login(browser, loginInformations, options) {
     await page.goto(loginInformations.url);
     //ensure page is loaded
     await page.waitForSelector(loginInformations.loginButtonSelector);
+    //simulate user waiting before typing login and password
+    await page.waitForTimeout(1000);
     //complete fields
     for (let index = 0; index < loginInformations.fields.length; index++) {
         let field = loginInformations.fields[index];
         await page.type(field.selector, field.value);
+        await page.waitForTimeout(500);
     }
+    //simulate user waiting before clicking on button
+    await page.waitForTimeout(1000);
     //click login button
     await page.click(loginInformations.loginButtonSelector);
 


### PR DESCRIPTION
feat(#83): Amélioration de la fonctionnalité login et ajout de waitForTimeout

Ajout de plusieurs timeouts en dur pour forcer la représentation "réaliste" d'un utilisateur qui se connecte sur une page d'authentification (afin d'éviter d'aller "trop vite").

En détail :
- Attente de 1s avant de saisir le login
- Attente de 0.5s après avoir saisi le login
- Attente de 0.5s après avoir saisi le mot de passe
- Attente de 1s avant de cliquer sur le bouton pour s'authentifier

Et enfin, en plus de `waitForSelector`, `waitForXPath` et `waitForNavigation`, j'ai ajouté `waitForTimeout` pour que, à n'importe quel moment d'un scénario utilisateur (y compris sur la phase d'authentification), on puisse définir une condition d'attente de manière à attendre X millisecondes.